### PR TITLE
Created setup.py for it to be able to install using pip

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -135,3 +135,6 @@ medline/*
 model.tar.gz
 wiki.en.bin
 labels.json
+
+# Vscode
+.vscode/

--- a/README.md
+++ b/README.md
@@ -3,6 +3,20 @@
 Detecting claim from scientific publication using [discourse model](https://github.com/Franck-Dernoncourt/pubmed-rct) and transfer learning. 
 Models are trained using [AllenNLP](https://github.com/allenai/allennlp) library.
 
+## Installing as a package
+
+You can install the package using PIP, which will help you use the `discourse` classes inside a module
+
+```bash
+pip install git+https://github.com/titipata/detecting-scientific-claim.git
+```
+
+you will be able to use them as
+
+```python
+import discourse
+predictor = discourse.DiscourseCRFClassifierPredictor()
+```
 
 ## Training discourse model
 

--- a/discourse/predictors/discourse_crf_predictor.py
+++ b/discourse/predictors/discourse_crf_predictor.py
@@ -6,7 +6,13 @@ from allennlp.common.util import JsonDict
 from allennlp.data import Instance
 from allennlp.predictors.predictor import Predictor
 
-nlp = spacy.load('en_core_web_sm')
+try:
+    nlp = spacy.load('en_core_web_sm')
+except Exception:
+    from spacy.cli import download
+    download("en_core_web_sm")
+    npl = spacy.load("en_core_web_sm")
+
 
 @Predictor.register('discourse_crf_predictor')
 class DiscourseCRFClassifierPredictor(Predictor):

--- a/setup.py
+++ b/setup.py
@@ -1,0 +1,26 @@
+from setuptools import setup, find_packages
+
+
+NAME = "DETECTING-SCIENTIFIC-CLAIM"
+VERSION = "1.0.0"
+DESCRIPTION = "Detecting Scientific Claims in Scientific literature."
+URL = "https://github.com/titipata/detecting-scientific-claim"
+
+EXCLUDE_LIST = [
+    "annotation_tool.*", "baseline.*", "experiments.*", "pubmed-rct.*",
+    "static_html.*", "arxivbot.*"
+]
+REQUIRED = [
+    "torch", "allennlp==0.9.0", "spacy", "fastText",
+    "pandas",
+]
+
+if __name__ == "__main__":
+    setup(
+        name=NAME,
+        version=VERSION,
+        packages=find_packages(exclude=EXCLUDE_LIST),
+        description=DESCRIPTION,
+        install_requires=REQUIRED,
+        url=URL,
+    )


### PR DESCRIPTION
changes done
-------------

setup.py
* requirements added using requirements.py and readme
* allennlp version specified, because some word tokenizer using to create predictors is not available in allennlp 1.0.0 (latest version)

readme
* added how to install this package

.gitignore
* added `.vscode` to remove the files created by vscode in course of my development

discourse/predictors/discourse_crf_predictor.py
* added a way to download "en_core_web_sm", in case it is not present in someone's virtual env ( was giving me error when fresh installing this package)
